### PR TITLE
Connect deck screen to state

### DIFF
--- a/components/DeckDisplay.js
+++ b/components/DeckDisplay.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import Deck from "./Deck";
 
@@ -34,17 +35,27 @@ const HighLight = styled.Text`
   font-weight: bold;
 `;
 
-const DeckDisplay = ({ name, description }) => (
+const DeckDisplay = ({ name, description, cardsCount }) => (
   <Item>
     <Deck />
     <TextWrapper>
       <Title>{name}</Title>
       <Description>{description}</Description>
       <TotalCards>
-        Cards: <HighLight>12</HighLight>
+        Cards: <HighLight>{cardsCount}</HighLight>
       </TotalCards>
     </TextWrapper>
   </Item>
 );
+
+DeckDisplay.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  cardsCount: PropTypes.number
+};
+
+DeckDisplay.defaultProps = {
+  cardsCount: 0
+};
 
 export default DeckDisplay;

--- a/components/DeckListItem.js
+++ b/components/DeckListItem.js
@@ -9,7 +9,7 @@ const Item = styled.TouchableOpacity`
 `;
 
 const DeckListItem = ({ navigation, deck }) => (
-  <Item onPress={() => navigation.navigate("Deck")}>
+  <Item onPress={() => navigation.navigate("Deck", { id: deck.id })}>
     <DeckDisplay {...deck} />
   </Item>
 );

--- a/navigation/MainTabNavigator.js
+++ b/navigation/MainTabNavigator.js
@@ -5,7 +5,7 @@ import {
 } from "react-navigation";
 import TabBarIcon from "../components/TabBarIcon";
 import HomeContainer from "../screens/HomeContainer";
-import DeckScreen from "../screens/DeckScreen";
+import DeckContainer from "../screens/DeckContainer";
 import NewCardScreen from "../screens/NewCardScreen";
 import NewDeckContainer from "../screens/NewDeckContainer";
 import QuizScreen from "../screens/QuizScreen";
@@ -13,7 +13,7 @@ import QuizScoreScreen from "../screens/QuizScoreScreen";
 
 const HomeStack = createStackNavigator({
   Home: HomeContainer,
-  Deck: DeckScreen,
+  Deck: DeckContainer,
   NewCard: NewCardScreen,
   Quiz: QuizScreen,
   QuizScore: QuizScoreScreen

--- a/screens/DeckContainer.js
+++ b/screens/DeckContainer.js
@@ -1,0 +1,9 @@
+import { connect } from "react-redux";
+import DeckScreen from "./DeckScreen";
+
+const mapStateToProps = ({ decks, cards }, { navigation }) => ({
+  deck: decks[navigation.getParam("id")] || null,
+  cards: []
+});
+
+export default connect(mapStateToProps)(DeckScreen);

--- a/screens/DeckScreen.js
+++ b/screens/DeckScreen.js
@@ -46,7 +46,10 @@ export default class DeckScreen extends React.Component {
   render() {
     return (
       <Container>
-        <DeckDisplay />
+        <DeckDisplay
+          {...this.props.deck}
+          cardsCount={this.props.cards.length}
+        />
         <StartQuiz onPress={() => this.props.navigation.navigate("Quiz")}>
           <FontAwesome name={"question-circle-o"} size={20} color="#FFF" />
           <ButtonLabel>Start Quiz</ButtonLabel>


### PR DESCRIPTION
## Why?

In order to keep a consistent navigation, I want to be directed to Deck page that is connected with the list item that I've clicked on the list page, and that it shows the correct amount of cards that it has.