### PR TITLE
Redirect user to newly created deck screen after success

### DIFF
--- a/actions/decks.js
+++ b/actions/decks.js
@@ -27,5 +27,6 @@ export const handleAddDeck = data => dispatch => {
       deck,
       key: id
     })
-    .then(() => dispatch(addDeck(deck)));
+    .then(() => dispatch(addDeck(deck)))
+    .then(({ deck }) => deck);
 };

--- a/screens/NewDeckContainer.js
+++ b/screens/NewDeckContainer.js
@@ -7,7 +7,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapProps = (state, { submitDeck }, { navigation }) => ({
-  onSubmit: deck => submitDeck(deck).then(() => navigation.navigate("Home"))
+  onSubmit: deck =>
+    submitDeck(deck).then(({ id }) => navigation.navigate("Deck", { id }))
 });
 
 export default connect(

--- a/screens/NewDeckScreen.js
+++ b/screens/NewDeckScreen.js
@@ -21,15 +21,20 @@ export default class NewDeckScreen extends React.Component {
     header: <Header>New Deck</Header>
   };
 
-  state = {
+  initialState = {
     name: "",
     description: "",
     error: false
   };
 
+  state = {
+    ...this.initialState
+  };
+
   handleSubmit = () => {
     const { name, description } = this.state;
     if (name !== "") {
+      this.setState({ ...this.initialState });
       return this.props.onSubmit({ name, description });
     }
     return this.setState({ error: true });
@@ -53,12 +58,14 @@ export default class NewDeckScreen extends React.Component {
             maxLength={30}
             onBlur={Keyboard.dismiss}
             onChangeText={e => this.handleChange(e, "name")}
+            value={this.state.name}
           />
           <Input
             placeholder="Description"
             maxLength={60}
             onBlur={Keyboard.dismiss}
             onChangeText={e => this.handleChange(e, "description")}
+            value={this.state.description}
           />
           {this.state.error && (
             <ErrorMessage>

--- a/screens/__snapshots__/NewDeckScreen.test.js.snap
+++ b/screens/__snapshots__/NewDeckScreen.test.js.snap
@@ -33,12 +33,14 @@ ShallowWrapper {
             onBlur={[Function]}
             onChangeText={[Function]}
             placeholder="Name"
+            value=""
           />
           <ForwardRef
             maxLength={60}
             onBlur={[Function]}
             onChangeText={[Function]}
             placeholder="Description"
+            value=""
           />
           <ForwardRef
             onPress={[Function]}
@@ -162,12 +164,14 @@ ShallowWrapper {
               onBlur={[Function]}
               onChangeText={[Function]}
               placeholder="Name"
+              value=""
             />,
             <ForwardRef
               maxLength={60}
               onBlur={[Function]}
               onChangeText={[Function]}
               placeholder="Description"
+              value=""
             />,
             false,
             <ForwardRef
@@ -190,6 +194,7 @@ ShallowWrapper {
               "onBlur": [Function],
               "onChangeText": [Function],
               "placeholder": "Name",
+              "value": "",
             },
             "ref": null,
             "rendered": null,
@@ -231,6 +236,7 @@ ShallowWrapper {
               "onBlur": [Function],
               "onChangeText": [Function],
               "placeholder": "Description",
+              "value": "",
             },
             "ref": null,
             "rendered": null,
@@ -402,12 +408,14 @@ ShallowWrapper {
               onBlur={[Function]}
               onChangeText={[Function]}
               placeholder="Name"
+              value=""
             />
             <ForwardRef
               maxLength={60}
               onBlur={[Function]}
               onChangeText={[Function]}
               placeholder="Description"
+              value=""
             />
             <ForwardRef
               onPress={[Function]}
@@ -531,12 +539,14 @@ ShallowWrapper {
                 onBlur={[Function]}
                 onChangeText={[Function]}
                 placeholder="Name"
+                value=""
               />,
               <ForwardRef
                 maxLength={60}
                 onBlur={[Function]}
                 onChangeText={[Function]}
                 placeholder="Description"
+                value=""
               />,
               false,
               <ForwardRef
@@ -559,6 +569,7 @@ ShallowWrapper {
                 "onBlur": [Function],
                 "onChangeText": [Function],
                 "placeholder": "Name",
+                "value": "",
               },
               "ref": null,
               "rendered": null,
@@ -600,6 +611,7 @@ ShallowWrapper {
                 "onBlur": [Function],
                 "onChangeText": [Function],
                 "placeholder": "Description",
+                "value": "",
               },
               "ref": null,
               "rendered": null,


### PR DESCRIPTION
## Why?

As a user, in order to have a seamless flow while using the app, I want to be redirected to the newly created deck screen after the success of the operation

As a user, in order to be natural to add as much decks I want, I want the form to be cleaned every submissions with success